### PR TITLE
fix: flow engine can go up to 35 degrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The following parameters can be controlled for the `climate` platform entities:
 The following attributes are available for diagnostic `sensor` platform entities:
 - Modbus serial (Device, Address, port, ...)
 - Target temperature (celcius) and throughput for each engine (maximum 4):
-  - Target temperature: Min: 15°C -> Max: 30°C
+  - Target temperature: Min: 15°C -> Max: 35°C
   - Troughput: int value between 0 (engine stopped) to 15 (maximum troughput)
 
 - Target temperature (celcius) for each area:

--- a/custom_components/koolnova_bms/koolnova/device.py
+++ b/custom_components/koolnova_bms/koolnova/device.py
@@ -205,8 +205,8 @@ class Engine:
         ''' Set order temp engine '''
         if not isinstance(val, float):
             raise AssertionError('Input variable must be Int')
-        if val > 0 and (val > 30.0 or val < 15.0):
-            raise OrderTempError('Flow Engine value ({}) must be between 15 and 30'.format(val))
+        if val > 0 and (val > 35.0 or val < 15.0):
+            raise OrderTempError('Flow Engine value ({}) must be between 15 and 35'.format(val))
         self._order_temp = val
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Hello, I managed to make it work.

I got this error:
```
2024-04-01 12:44:45.003 ERROR (MainThread) [custom_components.koolnova_bms.coordinator] Unexpected error fetching koolnova_bms data: Flow Engine value (32.5) must be between 15 and 30
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 318, in _async_refresh
self.data = await self._async_update_data()
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 274, in _async_update_data
return await self.update_method()
^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/koolnova_bms/koolnova/device.py", line 414, in async_update_all_areas
ret, self._engines[_idx - 1].order_temp = await self._client.async_engine_order_temp(engine_id = _idx)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/koolnova_bms/koolnova/device.py", line 209, in order_temp
raise OrderTempError('Flow Engine value ({}) must be between 15 and 30'.format(val))
custom_components.koolnova_bms.koolnova.device.OrderTempError: Flow Engine value (32.5) must be between 15 and 30
```

This should fix but I am still trying it by my side, since my device can accept temperature from 15 to 35 degrees, I don't know it if applies to all controllers but maybe that parameter should be configurable.