### PR TITLE
Fix ValueError when zone status register has upper bits set

### DIFF
--- a/custom_components/koolnova_bms/koolnova/operations.py
+++ b/custom_components/koolnova_bms/koolnova/operations.py
@@ -172,10 +172,10 @@ class Operations:
         for idx, reg in enumerate(regs):
             if idx % const.NUM_REG_PER_ZONE == 0:
                 zone_dict = {}
-                if const.ZoneRegister(reg >> 1) == const.ZoneRegister.REGISTER_ON:
+                if const.ZoneRegister((reg >> 1) & 0b1) == const.ZoneRegister.REGISTER_ON:
                     zone_dict['id'] = jdx
                     zone_dict['state'] = const.ZoneState(reg & 0b01)
-                    zone_dict['register'] = const.ZoneRegister(reg >> 1)
+                    zone_dict['register'] = const.ZoneRegister((reg >> 1) & 0b1)
                     flag = True
             elif idx % const.NUM_REG_PER_ZONE == 1 and flag:
                 zone_dict['fan'] = const.ZoneFanMode((reg & 0xF0) >> 4)
@@ -201,12 +201,12 @@ class Operations:
                                                 count = const.NUM_REG_PER_ZONE)
         if not ret:
             raise ReadRegistersError("Error reading holding register")
-        if const.ZoneRegister(regs[0] >> 1) == const.ZoneRegister.REGISTER_OFF:
+        if const.ZoneRegister((regs[0] >> 1) & 0b1) == const.ZoneRegister.REGISTER_OFF:
             _LOGGER.warning("Zone with id: {} is not registered".format(zone_id))
             return False, {}
 
         zone_dict['state'] = const.ZoneState(regs[0] & 0b01)
-        zone_dict['register'] = const.ZoneRegister(regs[0] >> 1)
+        zone_dict['register'] = const.ZoneRegister((regs[0] >> 1) & 0b1)
         zone_dict['fan'] = const.ZoneFanMode((regs[1] & 0xF0) >> 4)
         zone_dict['clim'] = const.ZoneClimMode(regs[1] & 0x0F)
         zone_dict['order_temp'] = regs[2]/2
@@ -225,11 +225,11 @@ class Operations:
             _idx:int = 4 * area_idx
             _area_dict:dict = {}
             # test if area is registered or not
-            if const.ZoneRegister(regs[_idx + const.REG_LOCK_ZONE] >> 1) == const.ZoneRegister.REGISTER_OFF:
+            if const.ZoneRegister((regs[_idx + const.REG_LOCK_ZONE] >> 1) & 0b1) == const.ZoneRegister.REGISTER_OFF:
                 continue
 
             _area_dict['state'] = const.ZoneState(regs[_idx + const.REG_LOCK_ZONE] & 0b01)
-            _area_dict['register'] = const.ZoneRegister(regs[_idx + const.REG_LOCK_ZONE] >> 1)
+            _area_dict['register'] = const.ZoneRegister((regs[_idx + const.REG_LOCK_ZONE] >> 1) & 0b1)
             _area_dict['fan'] = const.ZoneFanMode((regs[_idx + const.REG_STATE_AND_FLOW] & 0xF0) >> 4)
             _area_dict['clim'] = const.ZoneClimMode(regs[_idx + const.REG_STATE_AND_FLOW] & 0x0F)
             _area_dict['order_temp'] = regs[_idx + const.REG_TEMP_ORDER]/2
@@ -421,7 +421,7 @@ class Operations:
         if not ret:
             _LOGGER.error('Error retreive area register value')
             reg = 0
-        return ret, const.ZoneRegister(reg >> 1), const.ZoneState(reg & 0b01)
+        return ret, const.ZoneRegister((reg >> 1) & 0b1), const.ZoneState(reg & 0b01)
 
     async def async_set_area_state(self,
                                     id_zone:int = 0,


### PR DESCRIPTION
## Summary

The zone lock/state register (`REG_LOCK_ZONE`) is decoded as `ZoneRegister(reg >> 1)`. `ZoneRegister` only defines `REGISTER_OFF=0` and `REGISTER_ON=1`, so the `Enum(...)` call raises `ValueError` whenever any bit above bit 1 is set in that register. In practice this can happen — the BMS uses upper bits of that register for additional state that this integration doesn't currently model.

When the exception is raised from `async_setup_entry` (via `async_area_registered`) it propagates out before `device` and `coordinator` are stored in `hass.data`, which then breaks every platform setup with `KeyError: 'device'` / `KeyError: 'coordinator'`. All zones become unavailable in HA until the offending zone's upper bits clear.

## Reproduction

4-zone Koolnova system, slave 49, via Modbus TCP gateway. Zone 4 ("Bureau") was registered but in a scheduled-off state on the panel.

Direct read of holding registers 0–15 (slave 49):

```
zone1 reg0=3   binary=00000011   state=1   register>>1=1   OK
zone2 reg4=3   binary=00000011   state=1   register>>1=1   OK
zone3 reg8=3   binary=00000011   state=1   register>>1=1   OK
zone4 reg12=6  binary=00000110   state=0   register>>1=3   raises ValueError
```

After toggling zone 4 ON from the BMS panel, `reg12` returned to `3` and the integration loaded. The HA error chain in `home-assistant.log`:

```
ERROR custom_components.koolnova_bms: Something went wrong ... 3 is not a valid ZoneRegister
  File ".../__init__.py", line 76, in async_setup_entry
  File ".../koolnova/device.py", line 380, in async_add_manual_registered_area
  File ".../koolnova/operations.py", line 204, in async_area_registered
ERROR homeassistant.components.sensor:   Error while setting up koolnova_bms platform for sensor: 'device'
ERROR homeassistant.components.select:   Error while setting up koolnova_bms platform for select: 'device'
ERROR homeassistant.components.switch:   Error while setting up koolnova_bms platform for switch: 'device'
ERROR homeassistant.components.climate:  Error while setting up koolnova_bms platform for climate: 'coordinator'
```

The integration's broad `try/except Exception` in `async_setup_entry` swallows the original traceback, so the `Something went wrong ...` line is what surfaces in the log. The underlying error is `ValueError: 3 is not a valid ZoneRegister`, raised at the `ZoneRegister(reg >> 1)` call.

## Fix

Mask the value to bit 1 before constructing the enum, so unknown upper bits are ignored rather than fatal:

```python
const.ZoneRegister((reg >> 1) & 0b1)
```

Bit 0 (state) is already safely masked with `& 0b01`; this applies the same approach to the registered flag at all sites in `koolnova/operations.py` that decode `REG_LOCK_ZONE`:

- `async_discover_registered_areas`
- `async_area_registered` (the call site that triggered the bug here)
- `async_areas_registered`
- `async_area_state_and_register` — this one is reached at runtime by `async_set_area_state`, so without masking it the integration would crash whenever the user toggles a zone whose upper bits are set, even after the setup-time crash was avoided.

Safe interpretation of the upper bits: REGISTER_ON / REGISTER_OFF is bit 1 alone; everything above is treated as out-of-scope until the Koolnova spec documents it.

## Notes / follow-ups (out of scope for this PR)

- It would be useful to know what the upper bits of `REG_LOCK_ZONE` actually represent in the Koolnova BMS spec. Bit 2 in my testing correlated with a scheduled-off / manual-off state, but I don't have authoritative documentation. If you have the spec, decoding those bits as additional `ZoneRegister` enum values (or a separate sensor) would be a nice follow-up.
- `async_setup_entry` could also be made resilient to per-zone failures so a single bad register read doesn't take down the whole integration. Happy to open a separate PR for that if you'd like.

## Tested

- 4-zone system on a Modbus TCP gateway, slave 49.
- Reproduces 100% with a zone whose `reg[0] >> 1` has bit 1 set (e.g. raw value `6`).
- After patch, the integration loads cleanly with all 4 zones in either state, and toggling the affected zone no longer raises.